### PR TITLE
DPAD fix, Stretched Vs Native Resolution compile option + dynamic calculation, project compile properties update.

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -112,6 +112,7 @@
 									<listOptionValue builtIn="false" value="__QNXNTO__"/>
 									<listOptionValue builtIn="false" value="__PLAYBOOK__"/>
 								</option>
+								<option id="com.qnx.qcc.option.compiler.profile2.1434046818" name="Build for Profiling (Function Instrumentation) (-finstrument-functions)" superClass="com.qnx.qcc.option.compiler.profile2" value="false" valueType="boolean"/>
 								<inputType id="com.qnx.qcc.inputType.compiler.414014998" superClass="com.qnx.qcc.inputType.compiler"/>
 							</tool>
 							<tool id="com.qnx.qcc.tool.assembler.1548336396" name="QCC Assembler" superClass="com.qnx.qcc.tool.assembler">
@@ -130,6 +131,7 @@
 									<listOptionValue builtIn="false" value="asound"/>
 								</option>
 								<option id="com.qnx.qcc.option.linker.libraryPaths.615376583" name="Library Paths (-L)" superClass="com.qnx.qcc.option.linker.libraryPaths"/>
+								<option id="com.qnx.qcc.option.linker.profile2.1793375419" name="Build for Profiling (Function Instrumentation) (-lprofiling)" superClass="com.qnx.qcc.option.linker.profile2" value="false" valueType="boolean"/>
 								<inputType id="com.qnx.qcc.inputType.linker.113009118" superClass="com.qnx.qcc.inputType.linker">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>

--- a/.cproject
+++ b/.cproject
@@ -188,11 +188,11 @@
 									<listOptionValue builtIn="false" value="__QNXNTO__"/>
 									<listOptionValue builtIn="false" value="__PLAYBOOK__"/>
 								</option>
-								<option id="com.qnx.qcc.option.compile.debug.1889068178" name="Debug (-g)" superClass="com.qnx.qcc.option.compile.debug" value="true" valueType="boolean"/>
+								<option id="com.qnx.qcc.option.compile.debug.1889068178" name="Debug (-g)" superClass="com.qnx.qcc.option.compile.debug" value="false" valueType="boolean"/>
 								<inputType id="com.qnx.qcc.inputType.compiler.364806361" superClass="com.qnx.qcc.inputType.compiler"/>
 							</tool>
 							<tool id="com.qnx.qcc.tool.assembler.1047028274" name="QCC Assembler" superClass="com.qnx.qcc.tool.assembler">
-								<option id="com.qnx.qcc.option.assembler.debug.103710535" name="Debug (-g)" superClass="com.qnx.qcc.option.assembler.debug" value="true" valueType="boolean"/>
+								<option id="com.qnx.qcc.option.assembler.debug.103710535" name="Debug (-g)" superClass="com.qnx.qcc.option.assembler.debug" value="false" valueType="boolean"/>
 								<inputType id="com.qnx.qcc.inputType.assembler.96624985" superClass="com.qnx.qcc.inputType.assembler"/>
 							</tool>
 							<tool id="com.qnx.qcc.tool.linker.883634467" name="QCC Linker" superClass="com.qnx.qcc.tool.linker">
@@ -205,7 +205,7 @@
 									<listOptionValue builtIn="false" value="GLESv2"/>
 									<listOptionValue builtIn="false" value="asound"/>
 								</option>
-								<option id="com.qnx.qcc.option.linker.debug.484401559" name="Debug (-g)" superClass="com.qnx.qcc.option.linker.debug" value="true" valueType="boolean"/>
+								<option id="com.qnx.qcc.option.linker.debug.484401559" name="Debug (-g)" superClass="com.qnx.qcc.option.linker.debug" value="false" valueType="boolean"/>
 								<inputType id="com.qnx.qcc.inputType.linker.126797880" superClass="com.qnx.qcc.inputType.linker">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>

--- a/.project
+++ b/.project
@@ -28,7 +28,7 @@
 				</dictionary>
 				<dictionary>
 					<key>org.eclipse.cdt.make.core.buildLocation</key>
-					<value>${workspace_loc:/SDL12/Device-Release}</value>
+					<value>${workspace_loc:/SDL12/Device-Debug}</value>
 				</dictionary>
 				<dictionary>
 					<key>org.eclipse.cdt.make.core.contents</key>

--- a/src/video/playbook/SDL_playbooktouch.c
+++ b/src/video/playbook/SDL_playbooktouch.c
@@ -58,7 +58,7 @@ int handleDPad(int angle, int event)
 			} else if (angle <= -68) {
 				tmp[0] = 1;
 				// Up: -68 to -102
-			} else if (angle <= 23) {
+			} else if (angle <= -23) {
 				tmp[0] = 1;
 				tmp[2] = 1;
 				// Up-Right: -23 to -67

--- a/src/video/playbook/SDL_playbookvideo.c
+++ b/src/video/playbook/SDL_playbookvideo.c
@@ -330,8 +330,13 @@ SDL_Surface *PLAYBOOK_SetVideoMode(_THIS, SDL_Surface *current,
 
 #ifdef __STRETCHED__
 
-	int sizeOfWindow[2] = {1024, 600};
-
+	int sizeOfWindow[2];
+	rc = screen_get_window_property_iv(screenWindow, SCREEN_PROPERTY_SIZE, sizeOfWindow);
+		if (rc) {
+			SDL_SetError("Cannot get resolution: %s", strerror(errno));
+			screen_destroy_window(screenWindow);
+			return NULL;
+		}
 #else
 	int hwResolution[2];
 

--- a/src/video/playbook/SDL_playbookvideo.c
+++ b/src/video/playbook/SDL_playbookvideo.c
@@ -333,7 +333,12 @@ SDL_Surface *PLAYBOOK_SetVideoMode(_THIS, SDL_Surface *current,
 		return NULL;
 	}
 
+#ifdef __STRETCHED__
 	int sizeOfBuffer[2] = {width, height};
+#else
+	int sizeOfBuffer[2] = {sizeOfWindow[0], sizeOfWindow[1]};
+#endif
+
 	rc = screen_set_window_property_iv(screenWindow, SCREEN_PROPERTY_BUFFER_SIZE, sizeOfBuffer);
 	if (rc) {
 		SDL_SetError("Cannot resize window buffer: %s", strerror(errno));
@@ -416,8 +421,13 @@ SDL_Surface *PLAYBOOK_SetVideoMode(_THIS, SDL_Surface *current,
 	current->flags &= ~SDL_RESIZABLE; /* no resize for Direct Context */
 	current->flags |= SDL_FULLSCREEN;
 	current->flags |= SDL_HWSURFACE;
+#ifdef __STRETCHED__
 	current->w = width;
 	current->h = height;
+#else
+	current->w = sizeOfWindow[0];
+	current->h = sizeOfWindow[1];
+#endif
 	current->pitch = _priv->pitch;
 	current->pixels = _priv->pixels;
 	_priv->surface = current;


### PR DESCRIPTION
DPAD Fix 
- One of the angles was incorrect. (23 should be -23)

Stretched Vs Native Resolution + Dynamic Calculation
- Added the compile option **STRETCHED**.  
- If **STRETCHED** is defined the window size will be be set to the size returned by the hardware and the buffer will be set the the width and height passed in by the calling app.
- if **STRETCHED** is not defined the window size will be based on the size returned by the hardware and the width/height provided by the app.  It will calculate the best size that will fill most of the screen while maintaining the native aspect ratio. The the size of window and size of buffer are assigned these calculated values.

Project compile properties update
- I unchecked Debug (-g) box in the project properties for the Device-Release configuration.
