### PR TITLE
When not using TCO, send an SDL_USEREVENT with code 0 to indicate a

### DIFF
--- a/src/video/playbook/SDL_playbookevents.c
+++ b/src/video/playbook/SDL_playbookevents.c
@@ -742,6 +742,18 @@ void handleNavigatorEvent(_THIS, bps_event_t *event)
 	case NAVIGATOR_SWIPE_DOWN:
 		if (_priv->tcoControlsDir) {
 			tco_swipedown(_priv->emu_context, _priv->screenWindow);
+		} else {
+			SDL_Event event;
+			SDL_UserEvent userevent;
+
+			userevent.type = SDL_USEREVENT;
+			userevent.code = 0;
+			userevent.data1 = NULL;
+			userevent.data2 = NULL;
+			event.type = SDL_USEREVENT;
+			event.user = userevent;
+
+			SDL_PushEvent(&event);
 		}
 		break;
 	case NAVIGATOR_SWIPE_START:


### PR DESCRIPTION
NAVIGATOR_SWIPE_DOWN event.
