### PR TITLE
Added initial support for portrait orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+Device-*
+Simulator-*

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -646,7 +646,11 @@ SDL_Surface * SDL_SetVideoMode (int width, int height, int bpp, Uint32 flags)
 	/* Reset the keyboard here so event callbacks can run */
 	SDL_ResetKeyboard();
 	SDL_ResetMouse();
-	SDL_SetMouseRange(width, height);
+	if (getenv ("FORCE_PORTRAIT") != NULL) {
+		SDL_SetMouseRange(height, width);
+	} else {
+		SDL_SetMouseRange(width, height);
+	}
 	SDL_cursorstate &= ~CURSOR_USINGSW;
 
 	/* Clean up any previous video mode */

--- a/src/video/playbook/SDL_playbookvideo.c
+++ b/src/video/playbook/SDL_playbookvideo.c
@@ -413,7 +413,7 @@ SDL_Surface *PLAYBOOK_SetVideoMode(_THIS, SDL_Surface *current,
 
 	//int sizeOfWindow[2] = {600, 1204};
 	double newResolution[2];
-	if(hwRatio < appRatio){
+	if(hwRatio > appRatio){
 		newResolution[0] = ((double)height / ((double)hwResolution[1] / (double)hwResolution[0]));
 		newResolution[1] = (double)height;
 	}else{

--- a/src/video/playbook/SDL_playbookvideo.c
+++ b/src/video/playbook/SDL_playbookvideo.c
@@ -365,6 +365,13 @@ screen_window_t PLAYBOOK_CreateWindow(_THIS, SDL_Surface *current,
 SDL_Surface *PLAYBOOK_SetVideoMode(_THIS, SDL_Surface *current,
 				int width, int height, int bpp, Uint32 flags)
 {
+
+	if (getenv ("FORCE_PORTRAIT") != NULL) {
+		int cache = width;
+		width = height;
+		height = cache;
+	}
+
 //	fprintf(stderr, "SetVideoMode: %dx%d %dbpp\n", width, height, bpp);
 	if (width == 640 && height == 400) {
 		_priv->eventYOffset = 40;
@@ -404,9 +411,9 @@ SDL_Surface *PLAYBOOK_SetVideoMode(_THIS, SDL_Surface *current,
 	hwRatio = (float)hwResolution[0]/(float)hwResolution[1];
 	appRatio = (float)width/(float)height;
 
-//	int sizeOfWindow[2] = {816, 478};
+	//int sizeOfWindow[2] = {600, 1204};
 	double newResolution[2];
-	if(hwRatio > appRatio){
+	if(hwRatio < appRatio){
 		newResolution[0] = ((double)height / ((double)hwResolution[1] / (double)hwResolution[0]));
 		newResolution[1] = (double)height;
 	}else{

--- a/src/video/playbook/SDL_playbookvideo_gl.c
+++ b/src/video/playbook/SDL_playbookvideo_gl.c
@@ -122,6 +122,14 @@ SDL_Surface *PLAYBOOK_SetVideoMode_GL(_THIS, SDL_Surface *current,
 		goto error3;
 	}
 
+
+	if (getenv ("FORCE_PORTRAIT") != NULL) {
+		int cache = sizeOfWindow[0];
+		sizeOfWindow[0] = sizeOfWindow[1];
+		sizeOfWindow[1] = cache;
+	}
+
+
 	rc = screen_set_window_property_iv(screenWindow, SCREEN_PROPERTY_SIZE, sizeOfWindow);
 	if (rc) {
 		SDL_SetError("Cannot resize window: %s", strerror(errno));


### PR DESCRIPTION
SDL for BlackBerry has been designed for landscape only. We really need support for portrait orientation as well.

I had tried to add formal support for portrait orientation in the past, but somehow it never worked properly. Today I found a way to make it happen. This may not be the most elegant solution, but it's a start. At the right places, I have added a check for an environment variable called "FORCE_PORTRAIT", where it switches width and height values in order to render properly.

Both landscape and portrait are now working properly, so long as I specify the "FORCE_PORTRAIT" environment variable in my bar-descriptor.xml when needed.

This is important for a game we are bringing over today, but will also be vital for BlackBerry 10 smartphones, since portrait orientation will likely become much more common, particularly for a 720 x 720 device.
