### PR TITLE
Fix screen dimensions for BB10 devices

### DIFF
--- a/src/video/playbook/SDL_playbookvideo_gl.c
+++ b/src/video/playbook/SDL_playbookvideo_gl.c
@@ -74,7 +74,7 @@ SDL_Surface *PLAYBOOK_SetVideoMode_GL(_THIS, SDL_Surface *current,
 	EGLint configCount;
 	screen_window_t screenWindow;
 	int format = SCREEN_FORMAT_RGBX8888;
-	int sizeOfWindow[2] = {1024, 600};
+	int sizeOfWindow[2] = {this->info.current_w, this->info.current_h};
 	int sizeOfBuffer[2] = {width, height};
 	int usage = SCREEN_USAGE_OPENGL_ES1;
 	EGLint eglSurfaceAttributes[3] = { EGL_RENDER_BUFFER, EGL_BACK_BUFFER, EGL_NONE };


### PR DESCRIPTION
Instead of hard-coding the window size to 1024 x 600, this patch reuses the "current_w" and "current_h" values, which properly reflect the native screen resolution of the device.

After this change, both landscape and portrait are working properly. I have not tested on the PlayBook yet, but I see no reason this would not work properly there as well.
