### PR TITLE
Push BPS events using SDL_SysWMEvent

### DIFF
--- a/include/SDL_syswm.h
+++ b/include/SDL_syswm.h
@@ -183,10 +183,12 @@ typedef struct SDL_SysWMinfo {
 
 #elif defined(SDL_VIDEO_DRIVER_PLAYBOOK)
 #include <screen/screen.h>
+#include <bps/event.h>
 
+/** The PlayBook custom event structure */
 struct SDL_SysWMmsg {
 	SDL_version version;
-	int data;
+	bps_event_t *event;
 };
 
 typedef struct SDL_SysWMinfo {

--- a/src/video/playbook/SDL_playbookevents.c
+++ b/src/video/playbook/SDL_playbookevents.c
@@ -19,6 +19,7 @@
     Sam Lantinga
     slouken@libsdl.org
 */
+#include "SDL_syswm.h"
 #include "SDL_config.h"
 #include "SDL.h"
 #include "../../events/SDL_sysevents.h"
@@ -710,6 +711,14 @@ static void handleMtouchEvent(screen_event_t event, screen_window_t window, int 
 #endif
 }
 
+void handleCustomEvent(_THIS, bps_event_t *event)
+{
+	SDL_SysWMmsg wmmsg;
+	SDL_VERSION(&wmmsg.version);
+	wmmsg.event = event;
+	SDL_PrivateSysWMEvent(&wmmsg);
+}
+
 void handleNavigatorEvent(_THIS, bps_event_t *event)
 {
 	switch (bps_event_get_code(event))
@@ -841,6 +850,9 @@ PLAYBOOK_PumpEvents(_THIS)
 		}
 		else if (domain == screen_get_domain()) {
 			handleScreenEvent(this, event);
+		}
+		else {
+			handleCustomEvent(this, event);
 		}
 
 		bps_get_event(&event, 0);


### PR DESCRIPTION
Hi again,

I apologize for how the diff turned out on this commit. I'm using GitHub for Windows instead of using GIT from a terminal directly, and I was running into some trouble.

This makes a small change to the SDL_SysWMmsg struct for PlayBook, and adds "handleCustomEvent" in the PlayBook events file.

When a BPS event comes through that is not a navigator or screen event, it can now be pushed up using SDL_SysWMEvent, so long as the developer has used SDL_EventState (SDL_SYSWMEVENT, SDL_ENABLE); in his code.

Then you can get the BPS event if you catch a SDL_SYSWMEVENT, then use (inEvent.syswm.msg)->event

Now you can use the sensor API, BBM and other platform services while still using SDL. This seemed like the right place to put it, since SDL_SysWMEvent is platform-specific. Strictly speaking, I wouldn't consider BPS a window manager event, but using the existing SDL API in this way seemed like the cleanest way to handle other kinds of BPS events higher up the chain.
