### PR TITLE
SCREEN_PROPERTY_IDLE_MODE tied to getenv("SCREEN_IDLE_NORMAL")

### DIFF
--- a/src/video/playbook/SDL_playbookvideo.c
+++ b/src/video/playbook/SDL_playbookvideo.c
@@ -502,7 +502,7 @@ screen_window_t PLAYBOOK_CreateWindow(_THIS, SDL_Surface *current,
 {
 	screen_window_t screenWindow;
 	int rc = 0;
-	int idle_mode = SCREEN_IDLE_MODE_KEEP_AWAKE; // TODO: Handle idle gracefully?
+	int idle_mode = getenv("SCREEN_IDLE_NORMAL") != NULL ? SCREEN_IDLE_MODE_NORMAL : SCREEN_IDLE_MODE_KEEP_AWAKE;
 
 	if (_priv->screenWindow) {
 		if (current->hwdata)


### PR DESCRIPTION
Hello,

This patch lets SDL programs set the value of SCREEN_PROPERTY_IDLE_MODE via the environment variable SCREEN_IDLE_NORMAL. 

If getenv("SCREEN_IDLE_NORMAL") != NULL, then the property is set to SCREEN_IDLE_MODE_NORMAL. Otherwise, the default value is SCREEN_IDLE_MODE_KEEP_AWAKE.
