### PR TITLE
mainWindow is available through GetWMInfo

### DIFF
--- a/include/SDL_syswm.h
+++ b/include/SDL_syswm.h
@@ -89,7 +89,7 @@ typedef struct SDL_SysWMinfo {
 	    	Display *display;	/**< The X11 display */
 	    	Window window;		/**< The X11 display window */
 		/** These locking functions should be called around
-                 *  any X11 functions using the display variable, 
+                 *  any X11 functions using the display variable,
                  *  but not the gfxdisplay variable.
                  *  They lock the event thread, so should not be
 		 *  called around event functions or from event filters.
@@ -195,6 +195,7 @@ typedef struct SDL_SysWMinfo {
 	SDL_version version;
 	screen_context_t context;
 	screen_window_t window;
+	screen_window_t mainWindow;
 } SDL_SysWMinfo;
 
 #else
@@ -220,7 +221,7 @@ typedef struct SDL_SysWMinfo {
  * This function gives you custom hooks into the window manager information.
  * It fills the structure pointed to by 'info' with custom information and
  * returns 1 if the function is implemented.  If it's not implemented, or
- * the version member of the 'info' structure is invalid, it returns 0. 
+ * the version member of the 'info' structure is invalid, it returns 0.
  *
  * You typically use this function like this:
  * @code

--- a/src/video/playbook/SDL_playbookvideo.c
+++ b/src/video/playbook/SDL_playbookvideo.c
@@ -166,6 +166,7 @@ int PLAYBOOK_GetWMInfo(_THIS, SDL_SysWMinfo *info)
 	if ( info->version.major <= SDL_MAJOR_VERSION ) {
 		info->window = _priv->screenWindow;
 		info->context = _priv->screenContext;
+		info->mainWindow = _priv->mainWindow;
 		return(1);
 	} else {
 		SDL_SetError("Application not compiled with SDL %d.%d\n",
@@ -697,7 +698,7 @@ SDL_Surface *PLAYBOOK_SetVideoMode(_THIS, SDL_Surface *current,
 
 	locateTCOControlFile(this);
 	if (_priv->tcoControlsDir) {
-		initializeOverlay(this, screenWindow);	
+		initializeOverlay(this, screenWindow);
 	}
 
 	_priv->frontBuffer = windowBuffer[0];


### PR DESCRIPTION
Hello,

Sometimes it is handy to know the properties of the mainWindow before the screenWindow is created with SDL_SetVideoMode(). This patch exposes the mainWindow through GetWMInfo() so programs can query the mainWindow between SDL_Init() and SDL_SetVideoMode().

Sorry about the whitespace changes on a couple of extra lines. 
