### PR TITLE
don't clobber the bps_event

### DIFF
--- a/src/video/playbook/SDL_playbookevents.c
+++ b/src/video/playbook/SDL_playbookevents.c
@@ -752,17 +752,17 @@ void handleNavigatorEvent(_THIS, bps_event_t *event)
 		if (_priv->tcoControlsDir) {
 			tco_swipedown(_priv->emu_context, _priv->screenWindow);
 		} else {
-			SDL_Event event;
+			SDL_Event sdl_event;
 			SDL_UserEvent userevent;
 
 			userevent.type = SDL_USEREVENT;
 			userevent.code = 0;
 			userevent.data1 = NULL;
 			userevent.data2 = NULL;
-			event.type = SDL_USEREVENT;
-			event.user = userevent;
+			sdl_event.type = SDL_USEREVENT;
+			sdl_event.user = userevent;
 
-			SDL_PushEvent(&event);
+			SDL_PushEvent(&sdl_event);
 		}
 		break;
 	case NAVIGATOR_SWIPE_START:


### PR DESCRIPTION
Hello,

This patch changes a variable name in the NAVIGATOR_SWIPE_DOWN handler so that the bps_event_t\* passed to the event handler isn't clobbered by the SDL_Event of the same name later on. This isn't a problem now, but if someone later wanted to access the bps_event_t in that handler then they wouldn't be able to. 
