### PR TITLE
Post *all* native bps events to the client app as SDL_SYSWMEVENT events

### DIFF
--- a/src/video/playbook/SDL_playbookevents.c
+++ b/src/video/playbook/SDL_playbookevents.c
@@ -875,9 +875,9 @@ PLAYBOOK_PumpEvents(_THIS)
 		else if (domain == screen_get_domain()) {
 			handleScreenEvent(this, event);
 		}
-		else {
-			handleCustomEvent(this, event);
-		}
+
+		// post SDL_SYSWMEVENT event containing the bps event pointer
+		handleCustomEvent(this, event);
 
 		bps_get_event(&event, 0);
 	}


### PR DESCRIPTION
It's useful to have access to the navigator and screen events in the client app.
