### PR TITLE
FORCE_PORTRAIT is no longer necessary

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -646,11 +646,9 @@ SDL_Surface * SDL_SetVideoMode (int width, int height, int bpp, Uint32 flags)
 	/* Reset the keyboard here so event callbacks can run */
 	SDL_ResetKeyboard();
 	SDL_ResetMouse();
-	if (getenv ("FORCE_PORTRAIT") != NULL) {
-		SDL_SetMouseRange(height, width);
-	} else {
-		SDL_SetMouseRange(width, height);
-	}
+	
+	SDL_SetMouseRange(width, height);
+	
 	SDL_cursorstate &= ~CURSOR_USINGSW;
 
 	/* Clean up any previous video mode */


### PR DESCRIPTION
Due to other fixes, the FORCE_PORTRAIT define is no longer necessary, so this code was actually causing the wrong behavior for the mouse ranges.
